### PR TITLE
Convert build-playground/unit-tests/Github_Release_Test to Github Actions

### DIFF
--- a/.github/workflows/github_release_test.yml
+++ b/.github/workflows/github_release_test.yml
@@ -1,58 +1,77 @@
 name: build-playground/unit-tests/Github_Release_Test
 on:
-#   # The 'artifactSource' resource was not converted because GitHub does not support this type of trigger
-#   # This item has no matching transformer
-#   schedule:
-#     schedule:
-#       jobId: de5f9d5b-1865-4e11-b9ec-1ef8f3df2b33
-#       timeZoneId: UTC
-#       startHours: 3
-#       startMinutes: 0
-#       daysToRelease: 31
-#     triggerType: schedule
-#   # This item has no matching transformer
-#       jobId: 4053cea7-18f9-4708-9acd-73034a404dcd
-#       daysToRelease: 7
-#       jobId: d69cd9cc-f913-475d-9e72-1d4ddb9696c8
-#       daysToRelease: '8'
-#   sourceRepo:
-#     branchFilters:
-#     - "-main"
-#     - main
-#     alias: _azure_repo
-#     triggerType: sourceRepo
-#   # This item has no matching transformer
-#   # The 'package' resource was not transformed because workflows cannot be triggered on specific package in GitHub Actions
-#     alias: _begonaguereca_artifacts
+  workflow_dispatch:
 env:
-  ADMINUSERNAME: Begona
+  adminUserName: Begona
 jobs:
-  Stage-1:
+  Stage-1-job-1:
     runs-on: windows-latest
     concurrency:
       group: "${{ github.ref }}"
       cancel-in-progress: true
     env:
       ALT: one1, one2
-      FAVORITE_ICE_CREAM: Mango
-      FAVORITE_MOVIE: Pride and Prejudice
       TARGETS: suite1,suite2
+      favorite_ice_cream: Mango
+      favorite_movie: Pride and Prejudice
+    if: # roll back deployment stage triggers are not supported
+        github.event_type != 'pull_request'
     timeout-minutes: 99
     strategy:
     steps:
-#     # 'Git' was not transformed because there is no suitable equivalent in GitHub Actions
-#     # 'PackageManagement' was not transformed because there is no suitable equivalent in GitHub Actions
-#     # 'GitHub' was not transformed because there is no suitable equivalent in GitHub Actions
-#     # 'Jenkins' was not transformed because there is no suitable equivalent in GitHub Actions
-#     # This action relies on the workflow 'build-playground.yml' being present in this repository (change the repository parameter if the workflow is in a different repository).
-#     # Ensure the workflow exists and uploads an artifact for this to use.
-#     - uses: dawidd6/action-download-artifact@v2
-#       with:
-#         name: _azure_repo
-#         github_token: "${{ secrets.GITHUB_TOKEN }}"
-#         repo: "${{ github.repository }}"
-#     # 'DockerHub' was not transformed because there is no suitable equivalent in GitHub Actions
-#     # 'GitHubRelease' was not transformed because there is no suitable equivalent in GitHub Actions
+    # If `begonaguereca/artifacts` is the same as the current repository, the `token` property can be removed.
+    - uses: actions/checkout@v2
+      with:
+        repository: begonaguereca/artifacts
+        ref: main
+        fetch-depth: '1'
+        path: _begonaguereca_artifacts
+        submodules: 'true'
+        token: "${{ secrets.CHECKOUT_TOKEN }}"
+    - uses: Azure/login@v1
+      with:
+        creds: "${{ secrets.AZURE_CREDENTIALS }}"
+    - uses: azure/CLI@v1
+      with:
+        inlineScript: az storage blob download --name storage_this --file test
+    # If `build-playground/build-playground` is the same as the current repository, the `token` property can be removed.
+    - uses: actions/checkout@v2
+      with:
+        repository: build-playground/build-playground
+        path: _build-playground_tfvc
+        token: "${{ secrets.CHECKOUT_TOKEN }}"
+    - uses: dsaltares/fetch-gh-release-asset@0.06
+      with:
+        token: "${{ secrets.GITHUB_TOKEN }}"
+        repo: begonaguereca/American_Flag
+        version: '1.2'
+    - name: Authenticate GitHub Packages
+      uses: whelk-io/maven-settings-xml-action@v20
+      repositories: '[{"id":"1","url":"https://maven.pkg.github.com/${{ env.PACKAGES_OWNER }}/${{ env.PACKAGES_REPOSITORY }}"}]'
+      servers: '[{"id":"1","username":"${{ env.PACKAGES_USERNAME }}","password":"${{ secrets.PACKAGES_TOKEN }}"}]'
+    # # Ensure the following is included in your pom.xml file
+    # <dependencies>
+    #   <dependency>
+    #     <groupId>1</groupId>
+    #     <artifactId>1</artifactId>
+    #     <version>latest</version>
+    #   </dependency>
+    # </dependencies>
+    - name: Install Maven packages
+      run: mvn install -s ~/.m2/settings.xml
+    - name: Authenticate GitHub Packages
+      run: echo '//npm.pkg.github.com/:_authToken=${{ secrets.PACKAGES_TOKEN }}' > ~/.npmrc
+    - name: Install NPM packages
+      run: npm install @${{ env.PACKAGES_OWNER }}/1@latest --registry=https://npm.pkg.github.com/${{ env.PACKAGES_OWNER }}
+#     # GitHub Packages does not support downloading `python` packages
+#     # GitHub Packages does not support downloading `universal` packages
+    # If `valet-testing/dast` is the same as the current repository, the `token` property can be removed.
+    - uses: actions/checkout@v2
+      with:
+        repository: valet-testing/dast
+        ref: ''
+        path: _valet-testing_dast
+        token: "${{ secrets.CHECKOUT_TOKEN }}"
 #     # This item has no matching transformer
 #     - environment: {}
 #       taskId: a433f589-fce1-4460-9ee6-44a624aeb1fb
@@ -63,6 +82,7 @@ jobs:
 #       alwaysRun: false
 #       continueOnError: false
 #       timeoutInMinutes: 0
+#       retryCountOnTaskFailure: 0
 #       definitionType: task
 #       overrideInputs: {}
 #       condition: succeeded()
@@ -93,6 +113,7 @@ jobs:
 #       alwaysRun: false
 #       continueOnError: false
 #       timeoutInMinutes: 0
+#       retryCountOnTaskFailure: 0
 #       definitionType: task
 #       overrideInputs: {}
 #       condition: succeeded()
@@ -103,8 +124,11 @@ jobs:
 #         version: ''
 #         itemPattern: "**"
 #         downloadPath: "${{ github.workspace }}"
-    - name: Set up JDK
-      uses: actions/setup-java@v1
+    - name: Setup Java 16
+      uses: actions/setup-java@v2
+      with:
+        distribution: zulu
+        java-version: '16'
     - name: Ant ${{ env.TARGETS }} build.xml
       run: ant ${{ env.TARGETS }} -buildfile build.xml
     - name: Publish test results
@@ -114,66 +138,178 @@ jobs:
         files: "**/TEST-*.xml"
     - name: dotnet build
       run: dotnet build unicorn
-  Unicorn-Stage:
+  Stage-1-job-2:
     needs:
-    - Stage-1
-    runs-on: windows-latest
+    - Stage-1-job-1
+    runs-on: ubuntu-latest
     concurrency:
-#       # GitHub Actions does not support parallel deployments
+      group: "${{ github.ref }}"
+      cancel-in-progress: true
+    env:
+      ALT: one1, one2
+      TARGETS: suite1,suite2
+      favorite_ice_cream: Mango
+      favorite_movie: Pride and Prejudice
+    if: # roll back deployment stage triggers are not supported
+        github.event_type != 'pull_request'
     strategy:
     steps:
-#     # 'Git' was not transformed because there is no suitable equivalent in GitHub Actions
-#     # 'PackageManagement' was not transformed because there is no suitable equivalent in GitHub Actions
-#     # 'GitHub' was not transformed because there is no suitable equivalent in GitHub Actions
-#     # 'Jenkins' was not transformed because there is no suitable equivalent in GitHub Actions
-#     # This action relies on the workflow 'build-playground.yml' being present in this repository (change the repository parameter if the workflow is in a different repository).
-#     # Ensure the workflow exists and uploads an artifact for this to use.
-#     - uses: dawidd6/action-download-artifact@v2
-#       with:
-#         name: _azure_repo
-#         github_token: "${{ secrets.GITHUB_TOKEN }}"
-#         repo: "${{ github.repository }}"
-#     # 'DockerHub' was not transformed because there is no suitable equivalent in GitHub Actions
-#     # 'GitHubRelease' was not transformed because there is no suitable equivalent in GitHub Actions
 #     # This item has no matching transformer
 #     - environment: {}
-#       taskId: cbc316a2-586f-4def-be79-488a1f503564
-#       version: 0.*
-#       name: 'kubectl '
+#       taskId: 537fdb7a-a601-4537-aa70-92645a2b5ce4
+#       version: 1.*
+#       name: 'Azure Function: test.com'
 #       refName: ''
 #       enabled: true
 #       alwaysRun: false
 #       continueOnError: false
 #       timeoutInMinutes: 0
-#       definitionType:
+#       retryCountOnTaskFailure: 0
+#       definitionType: task
 #       overrideInputs: {}
 #       condition: succeeded()
 #       inputs:
-#         kubernetesServiceEndpoint: ''
-#         namespace: ''
-#         command: ''
-#         useConfigurationFile: 'false'
-#         configuration: ''
-#         arguments: ''
-#         secretType: dockerRegistry
-#         secretArguments: ''
-#         containerRegistryType: Azure Container Registry
-#         dockerRegistryEndpoint: ''
-#         azureSubscriptionEndpoint: ''
-#         azureContainerRegistry: ''
-#         secretName: ''
-#         forceUpdate: 'true'
-#         configMapName: ''
-#         forceUpdateConfigMap: 'false'
-#         useConfigMapFile: 'false'
-#         configMapFile: ''
-#         configMapArguments: ''
-#         versionOrLocation: version
-#         versionSpec: 1.7.0
-#         checkLatest: 'false'
-#         specifyLocation: ''
-#         cwd: "${{ github.workspace }}"
-#         outputFormat: json
-#         kubectlOutput: ''
+#         function: test.com
+#         key: '123455'
+#         method: POST
+#         headers: "{\n\"Content-Type\":\"application/json\", \n\"PlanUrl\": \"${{ env.system_CollectionUri }}\", \n\"ProjectId\": \"${{ env.system_TeamProjectId }}\", \n\"HubName\": \"build\", \n\"PlanId\": \"${{ env.system_PlanId }}\", \n\"JobId\": \"${{ github.job }}\", \n\"TimelineId\": \"${{ env.system_TimelineId }}\", \n\"TaskInstanceId\": \"${{ env.system_TaskInstanceId }}\", \n\"AuthToken\": \"${{ env.system_AccessToken }}\"\n}"
+#         queryParameters: ''
+#         body: ''
+#         waitForCompletion: 'false'
+#         successCriteria: ''
+#     # This item has no matching transformer
+#     - environment: {}
+#       taskId: 28782b92-5e8e-4458-9751-a71cd1492bae
+#       version: 1.*
+#       name: Delay by 0 minutes
+#       refName: ''
+#       enabled: true
+#       alwaysRun: false
+#       continueOnError: false
+#       timeoutInMinutes: 0
+#       retryCountOnTaskFailure: 0
+#       definitionType: task
+#       overrideInputs: {}
+#       condition: succeeded()
+#       inputs:
+#         delayForMinutes: '0'
+  Stage-1-job-3:
+    needs:
+    - Stage-1-job-2
+    runs-on: ubuntu-latest
+    concurrency:
+      group: "${{ github.ref }}"
+      cancel-in-progress: true
+    env:
+      ALT: one1, one2
+      TARGETS: suite1,suite2
+      favorite_ice_cream: Mango
+      favorite_movie: Pride and Prejudice
+    if: # roll back deployment stage triggers are not supported
+        github.event_type != 'pull_request'
+    timeout-minutes: 100
+    steps:
+    # If `begonaguereca/artifacts` is the same as the current repository, the `token` property can be removed.
+    - uses: actions/checkout@v2
+      with:
+        repository: begonaguereca/artifacts
+        ref: main
+        fetch-depth: '1'
+        path: _begonaguereca_artifacts
+        submodules: 'true'
+        token: "${{ secrets.CHECKOUT_TOKEN }}"
+    - uses: Azure/login@v1
+      with:
+        creds: "${{ secrets.AZURE_CREDENTIALS }}"
+    - uses: azure/CLI@v1
+      with:
+        inlineScript: az storage blob download --name storage_this --file test
+    # If `build-playground/build-playground` is the same as the current repository, the `token` property can be removed.
+    - uses: actions/checkout@v2
+      with:
+        repository: build-playground/build-playground
+        path: _build-playground_tfvc
+        token: "${{ secrets.CHECKOUT_TOKEN }}"
+    - uses: dsaltares/fetch-gh-release-asset@0.06
+      with:
+        token: "${{ secrets.GITHUB_TOKEN }}"
+        repo: begonaguereca/American_Flag
+        version: '1.2'
+    - name: Authenticate GitHub Packages
+      uses: whelk-io/maven-settings-xml-action@v20
+      repositories: '[{"id":"1","url":"https://maven.pkg.github.com/${{ env.PACKAGES_OWNER }}/${{ env.PACKAGES_REPOSITORY }}"}]'
+      servers: '[{"id":"1","username":"${{ env.PACKAGES_USERNAME }}","password":"${{ secrets.PACKAGES_TOKEN }}"}]'
+    # # Ensure the following is included in your pom.xml file
+    # <dependencies>
+    #   <dependency>
+    #     <groupId>1</groupId>
+    #     <artifactId>1</artifactId>
+    #     <version>latest</version>
+    #   </dependency>
+    # </dependencies>
+    - name: Install Maven packages
+      run: mvn install -s ~/.m2/settings.xml
+    - name: Authenticate GitHub Packages
+      run: echo '//npm.pkg.github.com/:_authToken=${{ secrets.PACKAGES_TOKEN }}' > ~/.npmrc
+    - name: Install NPM packages
+      run: npm install @${{ env.PACKAGES_OWNER }}/1@latest --registry=https://npm.pkg.github.com/${{ env.PACKAGES_OWNER }}
+#     # GitHub Packages does not support downloading `python` packages
+#     # GitHub Packages does not support downloading `universal` packages
+    # If `valet-testing/dast` is the same as the current repository, the `token` property can be removed.
+    - uses: actions/checkout@v2
+      with:
+        repository: valet-testing/dast
+        ref: ''
+        path: _valet-testing_dast
+        token: "${{ secrets.CHECKOUT_TOKEN }}"
+    - name: Setup Java 16
+      uses: actions/setup-java@v2
+      with:
+        distribution: zulu
+        java-version: '16'
+    - name: Ant  build.xml
+      run: ant -buildfile build.xml
+    - name: Publish test results
+      uses: EnricoMi/publish-unit-test-result-action@v1.7
+      if: always()
+      with:
+        files: "**/TEST-*.xml"
+  Unicorn-Stage:
+    needs:
+    - Stage-1-job-3
+    runs-on: windows-latest
+    concurrency:
+#       # GitHub Actions does not support parallel deployments
+    if: github.event_type != 'pull_request'
+    strategy:
+    steps:
+    # If `begonaguereca/artifacts` is the same as the current repository, the `token` property can be removed.
+    - uses: actions/checkout@v2
+      with:
+        repository: begonaguereca/artifacts
+        ref: main
+        fetch-depth: '1'
+        path: _begonaguereca_artifacts
+        submodules: 'true'
+        token: "${{ secrets.CHECKOUT_TOKEN }}"
+    - uses: Azure/login@v1
+      with:
+        creds: "${{ secrets.AZURE_CREDENTIALS }}"
+    - uses: azure/CLI@v1
+      with:
+        inlineScript: az storage blob download --name storage_this --file test
+    - uses: dsaltares/fetch-gh-release-asset@0.06
+      with:
+        token: "${{ secrets.GITHUB_TOKEN }}"
+        repo: begonaguereca/American_Flag
+        version: '1.2'
+    - name: kubectl
+      uses: azure/setup-kubectl@v1
+      with:
+        version: v1.7.0
+    - name: kubectl
+      shell: bash
+      working-directory: "${{ github.workspace }}"
+      run: kubectl  -o json
     - name: dotnet build
       run: dotnet build


### PR DESCRIPTION
Pipeline migrated from [Azure DevOps](https://dev.azure.com/valet-testing/build-playground/_release?_a=releases&definitionId=1) :tada:

## Manual steps

Perform the follow steps to complete the migration:

### build-playground/unit-tests/Github_Release_Test
- [ ] Ensure secret is available: `${{ secrets.CHECKOUT_TOKEN }}`
- [ ] Ensure secret is available: `${{ secrets.AZURE_CREDENTIALS }}`
- [ ] Ensure secret is available: `${{ secrets.PACKAGES_TOKEN }}`
- [ ] Ensure environment variable is updated: `${{ env.PACKAGES_OWNER }}`
- [ ] Ensure environment variable is updated: `${{ env.PACKAGES_REPOSITORY }}`
- [ ] Ensure environment variable is updated: `${{ env.PACKAGES_USERNAME }}`
- [ ] Ensure build tool is available: `ant`
- [ ] Ensure secret is available: `adminJob`